### PR TITLE
Ensure that tagged tests compile

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -34,6 +34,20 @@ runs:
         ./hack/update-codegen.sh
         popd
 
+    - name: Build
+      shell: bash
+      run: |
+        tags="$(grep -I  -r '// +build' . |
+                grep -v '^./vendor/' | \
+                grep -v '^./hack/' | \
+                grep -v '^./third_party' | \
+                cut -f3 -d' ' | \
+                sort | uniq | \
+                grep -v '^!' | \
+                tr '\n' ' ')"
+        echo "Building with tags: ${tags}"
+        go test -vet=off -tags "${tags}" -run=^$ ./...
+
     - name: Test Downstream
       shell: bash
       run: |


### PR DESCRIPTION
We had a breakage recently not caught by this test since it doesn't
exercise e2es. Actually running them is not feasible right now but this
will at least give us some confidence that they are buildable.

https://github.com/knative/eventing/pull/5378