### PR TITLE
Switch to a less hacky hack

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -47,7 +47,7 @@ runs:
                 grep -v '^!' | \
                 tr '\n' ' ')"
         echo "Building with tags: ${tags}"
-        go test -vet=off -tags "${tags}" -run=^$ ./...
+        go test -vet=off -tags "${tags}" -exec echo ./...
         popd
 
     - name: Test Downstream


### PR DESCRIPTION
-run=^$ has some weird behavior when it comes to init and TestMain functions, as you can see in this run:

https://github.com/knative/eventing/pull/5383/checks?check_run_id=2558873276

