### PR TITLE
Filter GOOS build tags

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -45,6 +45,8 @@ runs:
                 cut -f3 -d' ' | \
                 sort | uniq | \
                 grep -v '^!' | \
+                `# Don't pass any of the built-in GOOS tags` \
+                grep -vE '(windows|linux|darwin)' | \
                 tr '\n' ' ')"
         echo "Building with tags: ${tags}"
         go test -vet=off -tags "${tags}" -exec echo ./...


### PR DESCRIPTION
/kind bug

With this change, I can run the `go test` over Tekton.  This will need a release before it can be used...

**Release Note**


```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
